### PR TITLE
Add support for Neos Leak Sensors

### DIFF
--- a/wyzesense/gateway.py
+++ b/wyzesense/gateway.py
@@ -265,6 +265,13 @@ class Dongle(object):
                 sensor_type = "unknown"
                 sensor_state = "unknown"
             e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
+        elif event_type == 0xE8:
+            if alarm_data[0] == 0x03:
+                # alarm_data[7] might be humidity in some form, but as an integer
+                # is reporting way to high to actually be humidity.
+                sensor_type = "leak:temperature"
+                sensor_state = "%d.%d" % (alarm_data[5], alarm_data[6])
+            e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
         else:
             e = SensorEvent(sensor_mac, timestamp, "raw_%02X" % event_type, alarm_data)
 

--- a/wyzesense/gateway.py
+++ b/wyzesense/gateway.py
@@ -258,8 +258,11 @@ class Dongle(object):
             elif alarm_data[0] == 0x02:
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
+            elif alarm_data[0] == 0x03:
+                sensor_type = "leak"
+                sensor_state = "wet" if alarm_data[5] == 1 else "dry"
             else:
-                sesor_type = "uknown"
+                sensor_type = "unknown"
                 sensor_state = "unknown"
             e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
         else:


### PR DESCRIPTION
Tested with a Neos Smart Sense kit - contact and motion sensors work without any changes, this PR adds support for the leak detector and thermometer on leak sensors. I think the humidity sensor data is in `alarm_data[7]` on the same reports as temperature, but it's reporting much higher than an identical device viewed in the Neos app. (83% vs 66% from the app)