### PR TITLE
Fixed issue where an unknown packet would cause library to forcibly exit

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -20,13 +20,12 @@ from __future__ import print_function
 
 from builtins import input
 
-import os
 import re
 import sys
 import logging
-import errno
 import binascii
 import wyzesense
+
 
 def on_event(ws, e):
     s = "[%s][%s]" % (e.Timestamp.strftime("%Y-%m-%d %H:%M:%S"), e.MAC)
@@ -35,6 +34,7 @@ def on_event(ws, e):
     else:
         s += "RawEvent: type=%s, data=%r" % (e.Type, e.Data)
     print(s)
+
 
 def main(args):
     if args['--debug']:
@@ -56,7 +56,7 @@ def main(args):
     except IOError:
         print("No device found on path %r" % device)
         return 2
-    
+
     def List(unused_args):
         result = ws.List()
         print("%d sensor paired:" % len(result))
@@ -101,7 +101,7 @@ def main(args):
         cmd_and_args = input("Action:").strip().upper().split()
         if len(cmd_and_args) == 0:
             return True
-        
+
         cmd = cmd_and_args[0]
         if cmd not in cmd_handlers:
             return True
@@ -109,7 +109,7 @@ def main(args):
         handler = cmd_handlers[cmd]
         if not handler[1]:
             return False
-        
+
         handler[1](cmd_and_args[1:])
         return True
 
@@ -120,6 +120,7 @@ def main(args):
         ws.Stop()
 
     return 0
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s %(asctime)s %(message)s')

--- a/wyzesense/__main__.py
+++ b/wyzesense/__main__.py
@@ -18,14 +18,13 @@ from __future__ import print_function
 
 from builtins import input
 
-import os
 import re
 import sys
 import logging
-import errno
 import binascii
 
 from . import gateway as wyzesense
+
 
 def on_event(ws, e):
     s = "[%s][%s]" % (e.Timestamp.strftime("%Y-%m-%d %H:%M:%S"), e.MAC)
@@ -34,6 +33,7 @@ def on_event(ws, e):
     else:
         s += "RawEvent: type=%s, data=%r" % (e.Type, e.Data)
     print(s)
+
 
 def main(args):
     if args['--debug']:
@@ -55,7 +55,7 @@ def main(args):
     except IOError:
         print("No device found on path %r" % device)
         return 2
-    
+
     def List(unused_args):
         result = ws.List()
         print("%d sensor paired:" % len(result))
@@ -100,7 +100,7 @@ def main(args):
         cmd_and_args = input("Action:").strip().upper().split()
         if len(cmd_and_args) == 0:
             return True
-        
+
         cmd = cmd_and_args[0]
         if cmd not in cmd_handlers:
             return True
@@ -108,7 +108,7 @@ def main(args):
         handler = cmd_handlers[cmd]
         if not handler[1]:
             return False
-        
+
         handler[1](cmd_and_args[1:])
         return True
 
@@ -119,6 +119,7 @@ def main(args):
         ws.Stop()
 
     return 0
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s %(asctime)s %(message)s')

--- a/wyzesense/gateway.py
+++ b/wyzesense/gateway.py
@@ -3,15 +3,14 @@ from builtins import str
 
 import os
 import time
-import six
 import struct
 import threading
 import datetime
-import argparse
 import binascii
 
 import logging
 log = logging.getLogger(__name__)
+
 
 def bytes_to_hex(s):
     if s:
@@ -19,47 +18,51 @@ def bytes_to_hex(s):
     else:
         return "<None>"
 
+
 def checksum_from_bytes(s):
     return sum(bytes(s)) & 0xFFFF
 
-TYPE_SYNC   = 0x43
-TYPE_ASYNC  = 0x53
+
+TYPE_SYNC = 0x43
+TYPE_ASYNC = 0x53
+
 
 def MAKE_CMD(type, cmd):
     return (type << 8) | cmd
+
 
 class Packet(object):
     _CMD_TIMEOUT = 5
 
     # Sync packets:
     # Commands initiated from host side
-    CMD_GET_ENR               = MAKE_CMD(TYPE_SYNC, 0x02)
-    CMD_GET_MAC               = MAKE_CMD(TYPE_SYNC, 0x04)
-    CMD_GET_KEY               = MAKE_CMD(TYPE_SYNC, 0x06)
-    CMD_INQUIRY               = MAKE_CMD(TYPE_SYNC, 0x27)
-    CMD_UPDATE_CC1310         = MAKE_CMD(TYPE_SYNC, 0x12)
-    CMD_SET_CH554_UPGRADE     = MAKE_CMD(TYPE_SYNC, 0x0E)
+    CMD_GET_ENR = MAKE_CMD(TYPE_SYNC, 0x02)
+    CMD_GET_MAC = MAKE_CMD(TYPE_SYNC, 0x04)
+    CMD_GET_KEY = MAKE_CMD(TYPE_SYNC, 0x06)
+    CMD_INQUIRY = MAKE_CMD(TYPE_SYNC, 0x27)
+    CMD_UPDATE_CC1310 = MAKE_CMD(TYPE_SYNC, 0x12)
+    CMD_SET_CH554_UPGRADE = MAKE_CMD(TYPE_SYNC, 0x0E)
 
     # Async packets:
-    ASYNC_ACK                 = MAKE_CMD(TYPE_ASYNC, 0xFF)
+    ASYNC_ACK = MAKE_CMD(TYPE_ASYNC, 0xFF)
 
     # Commands initiated from dongle side
-    CMD_FINISH_AUTH           = MAKE_CMD(TYPE_ASYNC, 0x14)
-    CMD_GET_DONGLE_VERSION    = MAKE_CMD(TYPE_ASYNC, 0x16)
-    CMD_START_STOP_SCAN       = MAKE_CMD(TYPE_ASYNC, 0x1C)
-    CMD_GET_SENSOR_R1         = MAKE_CMD(TYPE_ASYNC, 0x21)
-    CMD_VERIFY_SENSOR         = MAKE_CMD(TYPE_ASYNC, 0x23)
-    CMD_DEL_SENSOR            = MAKE_CMD(TYPE_ASYNC, 0x25)
-    CMD_GET_SENSOR_COUNT      = MAKE_CMD(TYPE_ASYNC, 0x2E)
-    CMD_GET_SENSOR_LIST       = MAKE_CMD(TYPE_ASYNC, 0x30)
+    CMD_FINISH_AUTH = MAKE_CMD(TYPE_ASYNC, 0x14)
+    CMD_GET_DONGLE_VERSION = MAKE_CMD(TYPE_ASYNC, 0x16)
+    CMD_START_STOP_SCAN = MAKE_CMD(TYPE_ASYNC, 0x1C)
+    CMD_GET_SENSOR_R1 = MAKE_CMD(TYPE_ASYNC, 0x21)
+    CMD_VERIFY_SENSOR = MAKE_CMD(TYPE_ASYNC, 0x23)
+    CMD_DEL_SENSOR = MAKE_CMD(TYPE_ASYNC, 0x25)
+    CMD_GET_SENSOR_COUNT = MAKE_CMD(TYPE_ASYNC, 0x2E)
+    CMD_GET_SENSOR_LIST = MAKE_CMD(TYPE_ASYNC, 0x30)
 
     # Notifications initiated from dongle side
-    NOTIFY_SENSOR_ALARM       = MAKE_CMD(TYPE_ASYNC, 0x19)
-    NOTIFY_SENSOR_SCAN        = MAKE_CMD(TYPE_ASYNC, 0x20)
-    NOITFY_SYNC_TIME          = MAKE_CMD(TYPE_ASYNC, 0x32)
-    NOTIFY_EVENT_LOG          = MAKE_CMD(TYPE_ASYNC, 0x35)
+    NOTIFY_SENSOR_ALARM = MAKE_CMD(TYPE_ASYNC, 0x19)
+    NOTIFY_SENSOR_SCAN = MAKE_CMD(TYPE_ASYNC, 0x20)
+    NOITFY_SYNC_TIME = MAKE_CMD(TYPE_ASYNC, 0x32)
+    NOTIFY_EVENT_LOG = MAKE_CMD(TYPE_ASYNC, 0x35)
 
-    def __init__(self, cmd, payload = bytes()):
+    def __init__(self, cmd, payload=bytes()):
         self._cmd = cmd
         if self._cmd == self.ASYNC_ACK:
             assert isinstance(payload, int)
@@ -83,14 +86,14 @@ class Packet(object):
     @property
     def Cmd(self):
         return self._cmd
-    
+
     @property
     def Payload(self):
         return self._payload
 
     def Send(self, fd):
         pkt = bytes()
-        
+
         pkt += struct.pack(">HB", 0xAA55, self._cmd >> 8)
         if self._cmd == self.ASYNC_ACK:
             pkt += struct.pack("BB", (self._payload & 0xFF), self._cmd & 0xFF)
@@ -144,11 +147,11 @@ class Packet(object):
     @classmethod
     def GetVersion(cls):
         return cls(cls.CMD_GET_DONGLE_VERSION)
-    
+
     @classmethod
     def Inquiry(cls):
         return cls(cls.CMD_INQUIRY)
-    
+
     @classmethod
     def GetEnr(cls, r):
         assert isinstance(r, bytes)
@@ -158,7 +161,7 @@ class Packet(object):
     @classmethod
     def GetMAC(cls):
         return cls(cls.CMD_GET_MAC)
-        
+
     @classmethod
     def GetKey(cls):
         return cls(cls.CMD_GET_KEY)
@@ -189,7 +192,7 @@ class Packet(object):
         assert isinstance(mac, str)
         assert len(mac) == 8
         return cls(cls.CMD_DEL_SENSOR, mac.encode('ascii'))
-    
+
     @classmethod
     def GetSensorR1(cls, mac, r):
         assert isinstance(r, bytes)
@@ -221,13 +224,14 @@ class Packet(object):
         assert (cmd >> 0x8) == TYPE_ASYNC
         return cls(cls.ASYNC_ACK, cmd)
 
+
 class SensorEvent(object):
     def __init__(self, mac, timestamp, event_type, event_data):
         self.MAC = mac
         self.Timestamp = timestamp
         self.Type = event_type
         self.Data = event_data
-    
+
     def __str__(self):
         s = "[%s][%s]" % (self.Timestamp.strftime("%Y-%m-%d %H:%M:%S"), self.MAC)
         if self.Type == 'state':
@@ -235,6 +239,7 @@ class SensorEvent(object):
         else:
             s += "RawEvent: type=%s, data=%s" % (self.Type, bytes_to_hex(self.Data))
         return s
+
 
 class Dongle(object):
     _CMD_TIMEOUT = 2
@@ -250,7 +255,7 @@ class Dongle(object):
             return
 
         timestamp, event_type, sensor_mac = struct.unpack_from(">QB8s", pkt.Payload)
-        timestamp = datetime.datetime.fromtimestamp(timestamp/1000.0)
+        timestamp = datetime.datetime.fromtimestamp(timestamp / 1000.0)
         sensor_mac = sensor_mac.decode('ascii')
         alarm_data = pkt.Payload[17:]
         if event_type == 0xA2:
@@ -276,7 +281,7 @@ class Dongle(object):
         assert len(pkt.Payload) >= 9
         ts, msg_len = struct.unpack_from(">QB", pkt.Payload)
         # assert msg_len + 8 == len(pkt.Payload)
-        tm = datetime.datetime.fromtimestamp(ts/1000.0)
+        tm = datetime.datetime.fromtimestamp(ts / 1000.0)
         msg = pkt.Payload[9:]
         log.info("LOG: time=%s, data=%s", tm.isoformat(), bytes_to_hex(msg))
 
@@ -285,12 +290,12 @@ class Dongle(object):
         self.__fd = os.open(device, os.O_RDWR | os.O_NONBLOCK)
         self.__sensors = {}
         self.__exit_event = threading.Event()
-        self.__thread = threading.Thread(target = self._Worker)
+        self.__thread = threading.Thread(target=self._Worker)
         self.__on_event = event_handler
 
         self.__handlers = {
             Packet.NOITFY_SYNC_TIME: self._OnSyncTime,
-            Packet.NOTIFY_SENSOR_ALARM:  self._OnSensorAlarm,
+            Packet.NOTIFY_SENSOR_ALARM: self._OnSensorAlarm,
             Packet.NOTIFY_EVENT_LOG: self._OnEventLog,
         }
 
@@ -312,7 +317,7 @@ class Dongle(object):
         if length > 0x3F:
             length = 0x3F
 
-        #log.debug("Raw HID packet: %s", bytes_to_hex(s))
+        # log.debug("Raw HID packet: %s", bytes_to_hex(s))
         assert len(s) >= length + 1
         return s[1: 1 + length]
 
@@ -334,9 +339,9 @@ class Dongle(object):
         log.debug("<=== Received: %s", str(pkt))
         with self.__lock:
             handler = self.__handlers.get(pkt.Cmd, self._DefaultHandler)
-        
+
         if (pkt.Cmd >> 8) == TYPE_ASYNC and pkt.Cmd != Packet.ASYNC_ACK:
-            #log.info("Sending ACK packet for cmd %04X", pkt.Cmd)
+            # log.info("Sending ACK packet for cmd %04X", pkt.Cmd)
             self._SendPacket(Packet.AsyncAck(pkt.Cmd))
         handler(pkt)
 
@@ -345,10 +350,10 @@ class Dongle(object):
         while True:
             if self.__exit_event.isSet():
                 break
-            
+
             s += self._ReadRawHID()
-            #if s:
-            #    log.info("Incoming buffer: %s", bytes_to_hex(s))
+            # if s:
+            #     log.info("Incoming buffer: %s", bytes_to_hex(s))
             start = s.find(b"\x55\xAA")
             if start == -1:
                 time.sleep(0.1)
@@ -376,7 +381,7 @@ class Dongle(object):
             raise TimeoutError("_DoCommand")
 
     def _DoSimpleCommand(self, pkt, timeout=_CMD_TIMEOUT):
-        ctx = self.CmdContext(result = None)
+        ctx = self.CmdContext(result=None)
 
         def cmd_handler(pkt, e):
             ctx.result = pkt
@@ -398,7 +403,7 @@ class Dongle(object):
     def _GetEnr(self, r):
         log.debug("Start GetEnr...")
         assert len(r) == 4
-        assert all(isinstance(x,  int) for x in r)
+        assert all(isinstance(x, int) for x in r)
         r_string = bytes(struct.pack("<LLLL", *r))
 
         resp = self._DoSimpleCommand(Packet.GetEnr(r_string))
@@ -413,14 +418,14 @@ class Dongle(object):
         mac = resp.Payload.decode('ascii')
         log.debug("GetMAC returns %s", mac)
         return mac
-    
+
     def _GetKey(self):
         log.debug("Start GetKey...")
         resp = self._DoSimpleCommand(Packet.GetKey())
         assert len(resp.Payload) == 16
         log.debug("GetKey returns %s", resp.Payload)
         return resp.Payload
-    
+
     def _GetVersion(self):
         log.debug("Start GetVersion...")
         resp = self._DoSimpleCommand(Packet.GetVersion())
@@ -512,15 +517,15 @@ class Dongle(object):
         log.debug("Start Scan...")
 
         ctx = self.CmdContext(evt=threading.Event(), result=None)
+
         def scan_handler(pkt):
             assert len(pkt.Payload) == 11
             ctx.result = (pkt.Payload[1:9].decode('ascii'), pkt.Payload[9], pkt.Payload[10])
             ctx.evt.set()
-        
+
         old_handler = self._SetHandler(Packet.NOTIFY_SENSOR_SCAN, scan_handler)
         try:
             self._DoSimpleCommand(Packet.EnableScan())
-
 
             if ctx.evt.wait(timeout):
                 s_mac, s_type, s_ver = ctx.result

--- a/wyzesense/gateway.py
+++ b/wyzesense/gateway.py
@@ -125,10 +125,12 @@ class Packet(object):
             assert len(s) >= 7
             s = s[:7]
             payload = MAKE_CMD(cmd_type, b2)
-        else:
-            assert len(s) >= b2 + 4
+        elif len(s) >= b2 + 4:
             s = s[: b2 + 4]
             payload = s[5:-2]
+        else:
+            log.error("Invalid packet: %s", bytes_to_hex(s))
+            return None
 
         cs_remote = (s[-2] << 8) | s[-1]
         cs_local = checksum_from_bytes(s[:-2])
@@ -259,7 +261,7 @@ class Dongle(object):
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
             else:
-                sesor_type = "uknown"
+                sensor_type = "uknown"
                 sensor_state = "unknown"
             e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
         else:


### PR DESCRIPTION
Fixes #9 

There appears to be a type of packet that the library couldn't handle with the asserts around the payload. This change causes those packets to be ignored without triggering a Python asset error and crashing all code using this library. Ideally someone with more hardware skills could figure out what the errant packet is and take a meaningful action. It may be related to a sensor running low on battery, but am unable to confirm for sure.